### PR TITLE
pin streamlit to 1.7.0; st 1.8.0 drops `streamlit.script_runner` 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ lightning-cloud == 0.0.1
 lightning-flash[image,text]
 fiftyone
 ray[tune]
-streamlit
+streamlit == 1.7.0
 jinja2


### PR DESCRIPTION
latest streamlit release last week dropped `script_runner` which is required. Pin to 1.7.0 for now.