### PR TITLE
Fix for lightning master: replace `exposed_ports` with `port`, `exposed_url` with `url`

### DIFF
--- a/app.py
+++ b/app.py
@@ -34,7 +34,7 @@ class Flashy(LightningFlow):
                 )
 
     def configure_layout(self):
-        data_explorer_url = self.hpo.exposed_url("fiftyone")
+        data_explorer_url = self.hpo.exposed_url()
         if not self.hpo.fo.ready:
             data_explorer_url = "https://pl-flash-data.s3.amazonaws.com/assets_lightning/large_spinner.gif"
 

--- a/flashy/fiftyone_scheduler.py
+++ b/flashy/fiftyone_scheduler.py
@@ -12,7 +12,7 @@ from flashy.run_scheduler import _generate_script
 
 class FiftyOneTemplateTracer(TracerPythonScript):
     def __init__(self):
-        super().__init__(__file__, blocking=True, run_once=False, exposed_ports={"fiftyone": 5151})
+        super().__init__(__file__, blocking=True, run_once=False, port=5151)
 
         self._session = None
 

--- a/flashy/hpo_manager.py
+++ b/flashy/hpo_manager.py
@@ -114,8 +114,8 @@ class HPOManager(LightningFlow):
     def configure_layout(self):
         return StreamlitFrontend(render_fn=render_fn)
 
-    def exposed_url(self, key: str) -> str:
-        return self.fo.work.exposed_url(key)
+    def exposed_url(self) -> str:
+        return self.fo.work.url
 
 
 @add_flashy_styles


### PR DESCRIPTION
Fix for lightning master: replace `exposed_ports` with `port`, `exposed_url` with `url`

Relevant PR that had this change: https://github.com/PyTorchLightning/lightning/pull/577

cc: @ethanwharris 