### PR TITLE
Fix for lightning master, add fiftyone to requirements

### DIFF
--- a/flashy/components/flash_trainer.py
+++ b/flashy/components/flash_trainer.py
@@ -24,11 +24,6 @@ class FlashTrainer(TracerPythonScript):
         self.progress = None
         self._task_meta: Optional[TaskMeta] = None
 
-    def convert_path_to_str(self, data_config: dict):
-        for key, val in data_config.items():
-            if isinstance(val, Path):
-                data_config[key] = str(val)
-
     def run(
         self,
         task: str,
@@ -44,8 +39,6 @@ class FlashTrainer(TracerPythonScript):
 
         logging.info("Data config: {data_config}")
         logging.info("Task config: {task_config}")
-
-        self.convert_path_to_str(data_config)
 
         generate_script(
             self.script_path,

--- a/flashy/hpo_manager.py
+++ b/flashy/hpo_manager.py
@@ -86,15 +86,8 @@ class HPOManager(LightningFlow):
 
         self.dashboards = []
 
-    def _preprocess(self, data_config: dict):
-        for key, val in data_config.items():
-            if key.startswith("train_") or key.startswith("val_"):
-                data_config[key] = Path(val)
-
     def run(self, selected_task: str, data_config, url: str):
         self.selected_task = selected_task.lower().replace(" ", "_")
-
-        self._preprocess(data_config)
 
         if self.generated_runs is not None:
             self.has_run = True


### PR DESCRIPTION
- Added `init_globals` to overridden `_run_tracer` method.
- Added `fiftyone` to requirements temporarily. Ideally, it will be best if `requirements-cloud.txt` and `requirements-cpu.txt` can be used.