### PR TITLE
Update cloud compute

### DIFF
--- a/flashy/run_scheduler.py
+++ b/flashy/run_scheduler.py
@@ -17,7 +17,7 @@ class RunScheduler(WorkManager):
         for run in queued_runs:
             run_work = FlashTrainer(
                 cloud_compute=CloudCompute(
-                    "gpu" if run["model_config"].pop("use_gpu", False) else "cpu", 1
+                    "gpu" if run["model_config"].pop("use_gpu", False) else "cpu-small"
                 ),
             )
             self.register_work("runs", run["id"], run_work)


### PR DESCRIPTION
CloudCompute has changed on lightning master. https://github.com/PyTorchLightning/lightning/pull/767

- count has been removed
- "cpu" is no longer available. Either "default" which is the cheap free version or "cpu-small". 

https://lightning.ai/lightning-docs/core_api/lightning_work/compute.html#id1